### PR TITLE
General Debugger Cleanup for Usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # RuSuper
+
 gdb-style debugger of SNES roms. Upon starting the application, you will be prompted with a shell. You can use `help` to see the possible commands.
 
 ## Pre-requisites
+
     - Rustc 1.70.0+
 
 ## Usage
+
 `cargo run filename`. You can apply the following command line arguments as well:
 
--  `--no-check`: Skip the checksum check for target rom and write to memory directly.
-    - This is useful for test roms of very basic ASM.
-    - This is NOT useful for retail ROMs, as the header and checksum are important to discern the mapping of the rom.
-
-### Unimplemented/TBD
--   `--no-debug`: Run the program without executing the debugger. Currently hard coded to enable.
+`--retail` For properly writing a ROM into memory using the `Romdata` module
+  This is diabled by default currently to make testing with simplified ASM programs easier.
 
 ## Debugger Functionality
+
 The prefix `$` is allowed wherever an address literal is found to identify a hex value.
 
 - `help` or `h`: Display the **h**elp screen.

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -43,9 +43,7 @@ impl CpuState {
     }
 
     // Print the state of the CPU.
-    pub fn print_state(&self) {
-        self.registers.print_state();
-    }
+    pub fn print_state(&self) { self.registers.print_state(); }
 }
 /**************************************** File Scope Functions **********************************************************/
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -2,7 +2,7 @@ use registers::CpuRegisters;
 
 use crate::memory;
 
-mod instructions;
+pub(crate) mod instructions;
 mod registers;
 
 /**************************************** Constant Values ***************************************************************/

--- a/src/cpu/instructions.rs
+++ b/src/cpu/instructions.rs
@@ -52,15 +52,15 @@ enum CpuParamWidth {
 ///     - `width`       Width of next operation, to calculate parameters.
 ///     - `function`    Function pointer to handler for next operation.
 #[derive(Debug, Clone, Copy)]
-pub(super) struct CpuInstruction {
-    opcode: CpuOpcode,
+pub struct CpuInstruction {
+    pub opcode: CpuOpcode,
     width: CpuParamWidth,
     function: CpuInstructionFn,
 }
 
 /// Map of the cpu opcodes.
 /// Would prefer this to be a hashmap, but rust cannot generate a HashMap::From() as const, and a global cannot be declared using `let`.
-pub(super) const INSTRUCTION_MAP: [CpuInstruction; NUM_INSTRUCTIONS] = [
+pub(crate) const INSTRUCTION_MAP: [CpuInstruction; NUM_INSTRUCTIONS] = [
     CpuInstruction {
         opcode: CpuOpcode::Stp,
         width: CpuParamWidth::None,
@@ -1417,8 +1417,12 @@ pub(super) fn execute(
 
     // Call the function to execute.
     println!(
-        "Executing {:?} with parameter {:04X}",
-        inst.opcode, arg.param
+        "Executing {:?} ({:#04X}) parameter {:04X}",
+        inst.opcode,
+        arg.memory
+            .get_byte(arg.cpu.get_pc())
+            .expect("Failed to get PC"),
+        arg.param
     );
 
     let running = match (inst.function)(&mut arg) {

--- a/src/cpu/instructions.rs
+++ b/src/cpu/instructions.rs
@@ -41,10 +41,10 @@ pub(super) struct CpuInstructionFnArguments<'a> {
 #[derive(Debug, PartialEq, Clone, Copy)]
 enum CpuParamWidth {
     Variable = 0, // Paramater is variable width (depends on ALU setting)
-    None = 1,
-    Byte = 2, // Parameter is 8-bit (1 Byte)
-    Word = 3, // Parameter is 16-bit (1 Word)
-    Long = 4, // Parameter is 24-bit (long)
+    None     = 1,
+    Byte     = 2, // Parameter is 8-bit (1 Byte)
+    Word     = 3, // Parameter is 16-bit (1 Word)
+    Long     = 4, // Parameter is 24-bit (long)
 }
 
 /// A conglomerate wrapper of the prior enums.
@@ -1437,7 +1437,8 @@ pub(super) fn execute(
             registers::REGISTER_MODE_8_BIT => CpuParamWidth::Byte as u16,
             registers::REGISTER_MODE_16_BIT => CpuParamWidth::Word as u16,
         }
-    } else {
+    }
+    else {
         inst.width as u16
     };
 

--- a/src/cpu/registers.rs
+++ b/src/cpu/registers.rs
@@ -57,9 +57,7 @@ impl CpuRegisters {
     }
 
     /// Step the PC by `count` steps.
-    pub fn _step_pc(&mut self, count: u16) {
-        self.pc += count
-    }
+    pub fn _step_pc(&mut self, count: u16) { self.pc += count }
 
     /// Set a target flag.
     /// Parameters:
@@ -91,28 +89,24 @@ impl CpuRegisters {
     /// Returns:
     ///     - `false`: if flag is currently un-set
     ///     - `true`: if flag is currently set
-    pub fn get_flag(&self, flag: StatusFlags) -> bool {
-        self.status.flags[flag as usize]
-    }
+    pub fn get_flag(&self, flag: StatusFlags) -> bool { self.status.flags[flag as usize] }
 
     /// Get the stored register value of all of the flags.
-    pub fn _get_flag_vals(&self) -> u8 {
-        self.status.value.0
-    }
+    pub fn _get_flag_vals(&self) -> u8 { self.status.value.0 }
 }
 
 /// Status Flags.
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum StatusFlags {
-    Carry = 0,
-    Zero = 1,
+    Carry       = 0,
+    Zero        = 1,
     _IRQDisable = 2,
-    _Decimal = 3,
-    _IndexSize = 4,
-    AccSize = 5,
-    Overflow = 6,
-    Negative = 7,
+    _Decimal    = 3,
+    _IndexSize  = 4,
+    AccSize     = 5,
+    Overflow    = 6,
+    Negative    = 7,
 }
 
 ///

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -196,6 +196,7 @@ pub fn run(mut vm: VirtualMachine) {
         }
         // If the VM is not currently running, then prompt the user on the debugger.
         else {
+            vm.print_state();
             print!(">> ");
             io::stdout().flush().unwrap();
             check_dbg_input(&mut debugger, &mut vm);

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -22,9 +22,7 @@ pub struct InvalidDbgArgError {
 }
 
 impl fmt::Display for InvalidDbgArgError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.value)
-    }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{}", self.value) }
 }
 
 impl From<&str> for InvalidDbgArgError {
@@ -179,7 +177,8 @@ pub fn run(mut vm: VirtualMachine) {
             if let Some(value) = debugger.breakpoint_state.get(vm.cpu.get_pc()) {
                 vm.is_running = false;
                 println!("BREAK: Halted at {:#08X}", value);
-            } else {
+            }
+            else {
                 vm.is_running = emu::step_cpu(&mut vm);
             }
         }

--- a/src/debugger/breakpoints.rs
+++ b/src/debugger/breakpoints.rs
@@ -77,10 +77,12 @@ impl BreakpointFn for SetOp {
         // If there were no arguments passed just set a breakpoint at the PC if possible
         if args.is_empty() {
             cmd_result = debug.breakpoint_state.insert(vm.cpu.get_pc());
+            println!("Breakpoint set at {:#08X}", vm.cpu.get_pc());
         }
         // If it was a value then just push that on.
         else if let Ok((_, value)) = str_to_values(args, &debug.breakpoint_state, vm) {
             cmd_result = debug.breakpoint_state.insert(value);
+            println!("Breakpoint set at {:#08X}", value);
         } else if token_args.contains_tag() {
             // If the value was constructed purely from literals, or it was made of existing tags, throw it on.
             // Otherwise we need to make a new tag so try to do so.
@@ -88,10 +90,10 @@ impl BreakpointFn for SetOp {
             match test_tag {
                 Ok((tagname, value)) => match debug.breakpoint_state.insert_tag(&tagname, value) {
                     Some(value) => {
-                        println!("Updated tag {} to address {:#08X}", tagname, value);
+                        println!("Breakpoint \"{}\" updated to {:#08X}", tagname, value);
                     }
                     None => {
-                        println!("Set tag {} at address {:#08X}", tagname, value);
+                        println!("Breakpoint \"{}\" set at {:#08X}", tagname, value);
                     }
                 },
                 Err(e) => {
@@ -99,7 +101,6 @@ impl BreakpointFn for SetOp {
                 }
             }
         }
-
         cmd_result
     }
 }

--- a/src/debugger/breakpoints.rs
+++ b/src/debugger/breakpoints.rs
@@ -83,7 +83,8 @@ impl BreakpointFn for SetOp {
         else if let Ok((_, value)) = str_to_values(args, &debug.breakpoint_state, vm) {
             cmd_result = debug.breakpoint_state.insert(value);
             println!("Breakpoint set at {:#08X}", value);
-        } else if token_args.contains_tag() {
+        }
+        else if token_args.contains_tag() {
             // If the value was constructed purely from literals, or it was made of existing tags, throw it on.
             // Otherwise we need to make a new tag so try to do so.
             let test_tag = create_new_tag(&token_args, &debug.breakpoint_state, vm);
@@ -127,7 +128,8 @@ impl BreakpointFn for DeleteOp {
                 if let Some(_value) = debug.breakpoint_state.get(address) {
                     debug.breakpoint_state.delete(address);
                     println!("Deleted {:#08X} from breakpoints", address);
-                } else {
+                }
+                else {
                     return Err(InvalidDbgArgError::from(format!(
                         "Breakpoint {:#08X} does not exist",
                         address
@@ -141,7 +143,8 @@ impl BreakpointFn for DeleteOp {
                                 "Tag {} does not exist.",
                                 tag
                             )));
-                        } else {
+                        }
+                        else {
                             debug.breakpoint_state.delete_tag(&tag);
                             println!("Deleted {} from tags", &tag);
                         }
@@ -254,7 +257,8 @@ mod tests {
                         .breakpoint_op(test_input.as_slice(), &mut test_debug, &mut test_vm)
                         .unwrap();
                     assert!(test_debug.breakpoint_state.get(result).is_some());
-                } else {
+                }
+                else {
                     assert!(BreakpointSubCommandTypes::Set
                         .breakpoint_op(test_input.as_slice(), &mut test_debug, &mut test_vm)
                         .is_err());
@@ -305,7 +309,8 @@ mod tests {
                         .breakpoint_op(test_input.as_slice(), &mut test_debug, &mut test_vm)
                         .unwrap();
                     assert!(test_debug.breakpoint_state.get(result).is_some());
-                } else {
+                }
+                else {
                     assert!(BreakpointSubCommandTypes::Set
                         .breakpoint_op(test_input.as_slice(), &mut test_debug, &mut test_vm)
                         .is_err());

--- a/src/debugger/misc.rs
+++ b/src/debugger/misc.rs
@@ -76,7 +76,6 @@ impl DebugFn for PrintCommand {
         //        }
         //        Ok(())
         //    }
-        vm.cpu.print_state();
         vm.memory.print_bytes(None);
         Ok(())
     }

--- a/src/debugger/parser.rs
+++ b/src/debugger/parser.rs
@@ -117,7 +117,8 @@ impl TokenStreamHelpers for DebugTokenStream {
         }
         if !tags.is_empty() {
             Some(tags)
-        } else {
+        }
+        else {
             None
         }
     }
@@ -165,7 +166,8 @@ fn collect_args(argvec: Vec<&str>) -> Result<DebugTokenStream, InvalidDbgArgErro
                 _ => (),
             }
         }
-    } else {
+    }
+    else {
         return Err(InvalidDbgArgError::from("Length of args passed was 0"));
     }
     // If there's anything left in the value buffer at the end throw it on.
@@ -192,11 +194,13 @@ fn collect_tags(tokens: DebugTokenStream) -> DebugTokenStream {
                 // If the value is strictly numeric, just push it on as a value.
                 if data.is_decimal() {
                     new_vec.push(TokenSeparator::Value(data.to_string()));
-                } else if data.is_hex() {
+                }
+                else if data.is_hex() {
                     // If the value is in hex, check that the modifier was found to be present, or else we are looking at a tag name.
                     if let Some(TokenSeparator::HexValue) = last_token {
                         new_vec.push(TokenSeparator::Value(data.to_string()));
-                    } else {
+                    }
+                    else {
                         new_vec.push(TokenSeparator::Tag(data.to_string()));
                     }
                 }
@@ -235,7 +239,8 @@ fn deref_tags(
             if let Some(value) = table.get_tag(tagname) {
                 tag_as_value_stack.push(TokenSeparator::Value(value.to_hex_string()));
                 tag_as_value_stack.push(TokenSeparator::HexValue);
-            } else {
+            }
+            else {
                 tag_as_value_stack.push(TokenSeparator::Tag(tagname.to_string()));
             }
         }
@@ -400,7 +405,8 @@ fn compute_address_from_args(
                     return Err(InvalidDbgArgError::from(
                         "Value contained a tag which could not be dereferenced",
                     ));
-                } else {
+                }
+                else {
                     deref_args = tokens;
                 }
             }
@@ -442,7 +448,8 @@ fn compute_address_from_args(
             // Lastly, check if the computed value is within memory bounds.
             if val < MEMORY_END {
                 Ok(val)
-            } else {
+            }
+            else {
                 Err(InvalidDbgArgError::from(format!(
                     "Final value {:#X} was out of memory bounds.",
                     val
@@ -564,7 +571,8 @@ pub fn str_to_values(
     if let Some(value) = res_value {
         if let Some(tags) = res_tags {
             cmd_res = Ok((Some(tags.to_vec()), value));
-        } else {
+        }
+        else {
             cmd_res = Ok((None, value));
         }
     }
@@ -1328,7 +1336,8 @@ pub mod tests {
 
                     // Create a new debugger instance, because deletion is private to breakpoints
                     debug = DebuggerState::new();
-                } else {
+                }
+                else {
                     assert!(create_new_tag(&test_input, &debug.breakpoint_state, &vm).is_err());
                 }
             }
@@ -1379,7 +1388,8 @@ pub mod tests {
                     // Check that the outcome is correct.
                     assert_eq!(expected_tagname, tag_result.0);
                     assert_eq!(expected_value, tag_result.1);
-                } else {
+                }
+                else {
                     println!("\nTesting for error!");
                     println!(
                         "Result from create_new was: {:?}",
@@ -1450,7 +1460,8 @@ pub mod tests {
                         result,
                         str_to_values(&test_input, &test_debug.breakpoint_state, &test_vm).unwrap()
                     )
-                } else {
+                }
+                else {
                     assert!(
                         str_to_values(&test_input, &test_debug.breakpoint_state, &test_vm).is_err()
                     );
@@ -1502,7 +1513,8 @@ pub mod tests {
                         result,
                         compute_address_from_args(&test_input, &test_table, &test_vm).unwrap()
                     );
-                } else {
+                }
+                else {
                     assert!(compute_address_from_args(&test_input, &test_table, &test_vm).is_err());
                 }
             }

--- a/src/debugger/parser.rs
+++ b/src/debugger/parser.rs
@@ -117,8 +117,7 @@ impl TokenStreamHelpers for DebugTokenStream {
         }
         if !tags.is_empty() {
             Some(tags)
-        }
-        else {
+        } else {
             None
         }
     }
@@ -166,8 +165,7 @@ fn collect_args(argvec: Vec<&str>) -> Result<DebugTokenStream, InvalidDbgArgErro
                 _ => (),
             }
         }
-    }
-    else {
+    } else {
         return Err(InvalidDbgArgError::from("Length of args passed was 0"));
     }
     // If there's anything left in the value buffer at the end throw it on.
@@ -194,13 +192,11 @@ fn collect_tags(tokens: DebugTokenStream) -> DebugTokenStream {
                 // If the value is strictly numeric, just push it on as a value.
                 if data.is_decimal() {
                     new_vec.push(TokenSeparator::Value(data.to_string()));
-                }
-                else if data.is_hex() {
+                } else if data.is_hex() {
                     // If the value is in hex, check that the modifier was found to be present, or else we are looking at a tag name.
                     if let Some(TokenSeparator::HexValue) = last_token {
                         new_vec.push(TokenSeparator::Value(data.to_string()));
-                    }
-                    else {
+                    } else {
                         new_vec.push(TokenSeparator::Tag(data.to_string()));
                     }
                 }
@@ -239,8 +235,7 @@ fn deref_tags(
             if let Some(value) = table.get_tag(tagname) {
                 tag_as_value_stack.push(TokenSeparator::Value(value.to_hex_string()));
                 tag_as_value_stack.push(TokenSeparator::HexValue);
-            }
-            else {
+            } else {
                 tag_as_value_stack.push(TokenSeparator::Tag(tagname.to_string()));
             }
         }
@@ -319,14 +314,12 @@ fn deref_tags(
         }
     }
 
-
     // Reverse the stack back to the proper order.
     let mut result_tokens: DebugTokenStream = vec![];
     while let Some(token) = tag_as_value_stack.pop() {
         result_tokens.push(token);
     }
 
-    println!("Output from deref_tags is {:?}", result_tokens);
     Ok(result_tokens)
 }
 
@@ -407,8 +400,7 @@ fn compute_address_from_args(
                     return Err(InvalidDbgArgError::from(
                         "Value contained a tag which could not be dereferenced",
                     ));
-                }
-                else {
+                } else {
                     deref_args = tokens;
                 }
             }
@@ -450,8 +442,7 @@ fn compute_address_from_args(
             // Lastly, check if the computed value is within memory bounds.
             if val < MEMORY_END {
                 Ok(val)
-            }
-            else {
+            } else {
                 Err(InvalidDbgArgError::from(format!(
                     "Final value {:#X} was out of memory bounds.",
                     val
@@ -573,8 +564,7 @@ pub fn str_to_values(
     if let Some(value) = res_value {
         if let Some(tags) = res_tags {
             cmd_res = Ok((Some(tags.to_vec()), value));
-        }
-        else {
+        } else {
             cmd_res = Ok((None, value));
         }
     }
@@ -1338,8 +1328,7 @@ pub mod tests {
 
                     // Create a new debugger instance, because deletion is private to breakpoints
                     debug = DebuggerState::new();
-                }
-                else {
+                } else {
                     assert!(create_new_tag(&test_input, &debug.breakpoint_state, &vm).is_err());
                 }
             }
@@ -1374,7 +1363,6 @@ pub mod tests {
                 Some((TEST_TAG_NAME3, (TEST_BASE_ADDR + TEST_HEX_VALUE))), // tag3 tag + tag2
             ];
 
-
             for (test_input, expected_result) in zip(test_tag_tokens, numeric_results) {
                 test_table = ParserData::new();
                 test_table.insert_tag(TEST_TAG_NAME, TEST_BASE_ADDR);
@@ -1385,15 +1373,13 @@ pub mod tests {
                     test_input, expected_result
                 );
 
-
                 if let Some((expected_tagname, expected_value)) = expected_result {
                     let tag_result = create_new_tag(&test_input, &test_table, &vm).unwrap();
                     println!("Result was: {:?}", tag_result);
                     // Check that the outcome is correct.
                     assert_eq!(expected_tagname, tag_result.0);
                     assert_eq!(expected_value, tag_result.1);
-                }
-                else {
+                } else {
                     println!("\nTesting for error!");
                     println!(
                         "Result from create_new was: {:?}",
@@ -1464,8 +1450,7 @@ pub mod tests {
                         result,
                         str_to_values(&test_input, &test_debug.breakpoint_state, &test_vm).unwrap()
                     )
-                }
-                else {
+                } else {
                     assert!(
                         str_to_values(&test_input, &test_debug.breakpoint_state, &test_vm).is_err()
                     );
@@ -1517,8 +1502,7 @@ pub mod tests {
                         result,
                         compute_address_from_args(&test_input, &test_table, &test_vm).unwrap()
                     );
-                }
-                else {
+                } else {
                     assert!(compute_address_from_args(&test_input, &test_table, &test_vm).is_err());
                 }
             }

--- a/src/debugger/parser_data.rs
+++ b/src/debugger/parser_data.rs
@@ -28,9 +28,7 @@ impl ParserData {
     /// # Returns:
     ///     - `Some(&usize)`:   Address existing at that tag.
     ///     - `None`:           If no value exists for that tag name.
-    pub fn get_tag(&self, tag: &str) -> Option<&usize> {
-        self.tag_db.get(tag)
-    }
+    pub fn get_tag(&self, tag: &str) -> Option<&usize> { self.tag_db.get(tag) }
 
     /// Look to see if the table contains a tag, and return it's name if so.
     /// # Parameters:
@@ -39,9 +37,7 @@ impl ParserData {
     /// # Returns:
     ///     - `Some(tagname)`:  The name of the tag, if found.
     ///     - `None`:           If the tag was not present in the list.
-    pub fn get_tag_name(&self, address: usize) -> Option<&str> {
-        self.tag_db.find_key(address)
-    }
+    pub fn get_tag_name(&self, address: usize) -> Option<&str> { self.tag_db.find_key(address) }
 
     /// Wrapper for inserting a breakpoint with a tag and an address.
     /// If a tag is already present, updates the value and returns it, Otherwise, inserts into the
@@ -61,7 +57,8 @@ impl ParserData {
             self.addresses.remove_value(old_value);
             self.addresses.push(address);
             Some(address)
-        } else {
+        }
+        else {
             self.addresses.push(address);
             None
         }
@@ -92,7 +89,8 @@ impl ParserData {
     pub fn get(&self, address: usize) -> Option<usize> {
         if self.addresses.contains(&address) {
             Some(address)
-        } else {
+        }
+        else {
             None
         }
     }
@@ -113,13 +111,15 @@ impl ParserData {
                     "Breakpoint {} already exists at {:#08X}",
                     name, value
                 )))
-            } else {
+            }
+            else {
                 Err(InvalidDbgArgError::from(format!(
                     "A breakpoint was already set at {:#08X}",
                     value
                 )))
             }
-        } else {
+        }
+        else {
             self.addresses.push(address);
             Ok(())
         }
@@ -135,7 +135,8 @@ impl ParserData {
     pub fn delete(&mut self, address: usize) -> Option<usize> {
         if self.addresses.remove_value(address) {
             Some(address)
-        } else {
+        }
+        else {
             None
         }
     }

--- a/src/debugger/parser_data.rs
+++ b/src/debugger/parser_data.rs
@@ -39,7 +39,7 @@ impl ParserData {
     ///     - `None`:           If the tag was not present in the list.
     pub fn get_tag_name(&self, address: usize) -> Option<&str> { self.tag_db.find_key(address) }
 
-    /// Wrapper for inserting a breakpoint with a tag and an address.
+    /// Wrapper for inserting a value with a tag and an address.
     /// If a tag is already present, updates the value and returns it, Otherwise, inserts into the
     /// table.
     ///
@@ -79,7 +79,7 @@ impl ParserData {
         None
     }
 
-    /// Check if a value is present in the breakpoint table.
+    /// Check if a value is present in the table.
     /// # Parameters:
     ///     - `self`
     ///     - `address`: Address to test.
@@ -108,13 +108,13 @@ impl ParserData {
         if let Some(value) = self.get(address) {
             if let Some(name) = self.tag_db.find_key(address) {
                 Err(InvalidDbgArgError::from(format!(
-                    "Breakpoint {} already exists at {:#08X}",
+                    "Tag {} already exists at {:#08X}",
                     name, value
                 )))
             }
             else {
                 Err(InvalidDbgArgError::from(format!(
-                    "A breakpoint was already set at {:#08X}",
+                    "A value already exists at {:#08X}",
                     value
                 )))
             }
@@ -128,7 +128,7 @@ impl ParserData {
     /// Wrapper for utils::remove_value.
     /// # Parameters:
     ///     - `&mut self`
-    ///     - `address`: The value to remove from the breakpoint list.
+    ///     - `address`: The value to remove from the list.
     /// # Returns:
     ///     - `Some(address)`:  The address that was removed from the table
     ///     - `None`:           If the address was not present in the table.

--- a/src/debugger/parser_data.rs
+++ b/src/debugger/parser_data.rs
@@ -28,7 +28,9 @@ impl ParserData {
     /// # Returns:
     ///     - `Some(&usize)`:   Address existing at that tag.
     ///     - `None`:           If no value exists for that tag name.
-    pub fn get_tag(&self, tag: &str) -> Option<&usize> { self.tag_db.get(tag) }
+    pub fn get_tag(&self, tag: &str) -> Option<&usize> {
+        self.tag_db.get(tag)
+    }
 
     /// Look to see if the table contains a tag, and return it's name if so.
     /// # Parameters:
@@ -37,7 +39,9 @@ impl ParserData {
     /// # Returns:
     ///     - `Some(tagname)`:  The name of the tag, if found.
     ///     - `None`:           If the tag was not present in the list.
-    pub fn get_tag_name(&self, address: usize) -> Option<&str> { self.tag_db.find_key(address) }
+    pub fn get_tag_name(&self, address: usize) -> Option<&str> {
+        self.tag_db.find_key(address)
+    }
 
     /// Wrapper for inserting a breakpoint with a tag and an address.
     /// If a tag is already present, updates the value and returns it, Otherwise, inserts into the
@@ -57,8 +61,7 @@ impl ParserData {
             self.addresses.remove_value(old_value);
             self.addresses.push(address);
             Some(address)
-        }
-        else {
+        } else {
             self.addresses.push(address);
             None
         }
@@ -89,8 +92,7 @@ impl ParserData {
     pub fn get(&self, address: usize) -> Option<usize> {
         if self.addresses.contains(&address) {
             Some(address)
-        }
-        else {
+        } else {
             None
         }
     }
@@ -111,15 +113,13 @@ impl ParserData {
                     "Breakpoint {} already exists at {:#08X}",
                     name, value
                 )))
-            }
-            else {
+            } else {
                 Err(InvalidDbgArgError::from(format!(
                     "A breakpoint was already set at {:#08X}",
                     value
                 )))
             }
-        }
-        else {
+        } else {
             self.addresses.push(address);
             Ok(())
         }
@@ -135,8 +135,7 @@ impl ParserData {
     pub fn delete(&mut self, address: usize) -> Option<usize> {
         if self.addresses.remove_value(address) {
             Some(address)
-        }
-        else {
+        } else {
             None
         }
     }
@@ -156,7 +155,6 @@ impl ParserData {
             }
             println!();
         }
-        println!("  \n-----------------------");
     }
 }
 

--- a/src/debugger/step.rs
+++ b/src/debugger/step.rs
@@ -58,7 +58,8 @@ impl DebugFn for StepCommand {
         // If the user asked to step with no argument pass it to step once.
         if args.is_empty() {
             StepSubCommandTypes::Step.step_op(args, debug, vm)
-        } else {
+        }
+        else {
             let sub = StepSubCommandTypes::from(args[0]);
             match sub {
                 StepSubCommandTypes::Step => sub.step_op(args, debug, vm),

--- a/src/emu.rs
+++ b/src/emu.rs
@@ -1,6 +1,7 @@
 use std::time;
 
 use crate::cpu;
+use crate::cpu::instructions::INSTRUCTION_MAP;
 use crate::debugger;
 use crate::memory;
 use crate::romdata;
@@ -55,6 +56,20 @@ impl VirtualMachine {
             is_running: false,
         }
     }
+
+    pub fn print_state(&self) {
+        self.cpu.print_state();
+
+        let pc_val = self
+            .memory
+            .get_byte(self.cpu.get_pc())
+            .expect("Could not get value at PC from memory");
+
+        println!(
+            "Instruction at PC is: {:#04X} ({:?})",
+            pc_val, INSTRUCTION_MAP[pc_val as usize].opcode
+        );
+    }
 }
 
 /**************************************** File Scope Functions **********************************************************/
@@ -72,12 +87,10 @@ pub fn run(path: std::path::PathBuf, args: Vec<String>) {
     if args.len() > 2 {
         if args[2] == "--no-check" {
             vm.romdata = romdata::load_rom(path, &mut vm.memory, true).unwrap();
-        }
-        else {
+        } else {
             vm.romdata = romdata::load_rom(path, &mut vm.memory, false).unwrap();
         }
-    }
-    else {
+    } else {
         // Initialize the VM and then load the ROM into memory.
         vm.romdata = romdata::load_rom(path, &mut vm.memory, false).unwrap();
     }
@@ -92,8 +105,7 @@ pub fn run(path: std::path::PathBuf, args: Vec<String>) {
     let debugger_enabled = true;
     if debugger_enabled {
         debugger::run(vm);
-    }
-    else {
+    } else {
         vm.is_running = true;
         while vm.is_running {
             // TODO: Should CPU be threaded or should this file be the king?

--- a/src/emu.rs
+++ b/src/emu.rs
@@ -85,11 +85,11 @@ pub fn run(path: std::path::PathBuf, args: Vec<String>) {
     let mut vm = VirtualMachine::new();
     // TODO: https://github.com/HunterKing/RuSuper/issues/27
     if args.len() > 2 {
-        if args[2] == "--no-check" {
-            vm.romdata = romdata::load_rom(path, &mut vm.memory, true).unwrap();
+        if args[2] == "--retail" {
+            vm.romdata = romdata::load_rom(path, &mut vm.memory, false).unwrap();
         }
         else {
-            vm.romdata = romdata::load_rom(path, &mut vm.memory, false).unwrap();
+            vm.romdata = romdata::load_rom(path, &mut vm.memory, true).unwrap();
         }
     }
     else {

--- a/src/emu.rs
+++ b/src/emu.rs
@@ -87,10 +87,12 @@ pub fn run(path: std::path::PathBuf, args: Vec<String>) {
     if args.len() > 2 {
         if args[2] == "--no-check" {
             vm.romdata = romdata::load_rom(path, &mut vm.memory, true).unwrap();
-        } else {
+        }
+        else {
             vm.romdata = romdata::load_rom(path, &mut vm.memory, false).unwrap();
         }
-    } else {
+    }
+    else {
         // Initialize the VM and then load the ROM into memory.
         vm.romdata = romdata::load_rom(path, &mut vm.memory, false).unwrap();
     }
@@ -105,7 +107,8 @@ pub fn run(path: std::path::PathBuf, args: Vec<String>) {
     let debugger_enabled = true;
     if debugger_enabled {
         debugger::run(vm);
-    } else {
+    }
+    else {
         vm.is_running = true;
         while vm.is_running {
             // TODO: Should CPU be threaded or should this file be the king?

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -21,9 +21,7 @@ pub struct InvalidAddressError {
 }
 
 impl InvalidAddressError {
-    pub fn new(addr: usize) -> Self {
-        Self { addr }
-    }
+    pub fn new(addr: usize) -> Self { Self { addr } }
 }
 
 impl fmt::Display for InvalidAddressError {
@@ -183,7 +181,8 @@ pub fn compose_address(bank: u8, byte_addr: u16) -> usize {
 pub fn address_is_valid(address: usize) -> Result<(), InvalidAddressError> {
     if address < MEMORY_SIZE {
         Ok(())
-    } else {
+    }
+    else {
         println!("Error");
         Err(InvalidAddressError::new(address))
     }

--- a/src/romdata.rs
+++ b/src/romdata.rs
@@ -127,8 +127,8 @@ type ExceptionVectorTable = [u8; EV_LEN_BYTES];
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(usize)]
 pub enum RomSize {
-    LoRom = LO_ROM_HEADER_ADDR,
-    HiRom = HI_ROM_HEADER_ADDR,
+    LoRom   = LO_ROM_HEADER_ADDR,
+    HiRom   = HI_ROM_HEADER_ADDR,
     ExHiRom = EX_HI_ROM_HEADER_ADDR,
 }
 const ROM_SIZE_NUM: usize = 3;
@@ -171,14 +171,14 @@ impl From<RomCoProcessor> for RomExpansions {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum CartType {
-    ROMOnly = 0x00,
-    ROMSram = 0x01,
-    ROMSramBattery = 0x02,
-    ROMCoCpu = 0x03,
-    ROMCoCpuSram = 0x04,
+    ROMOnly             = 0x00,
+    ROMSram             = 0x01,
+    ROMSramBattery      = 0x02,
+    ROMCoCpu            = 0x03,
+    ROMCoCpuSram        = 0x04,
     ROMCoCpuSramBattery = 0x05,
-    ROMCoCpuBattery = 0x06,
-    None = 0x07,
+    ROMCoCpuBattery     = 0x06,
+    None                = 0x07,
 }
 const CART_TYPE_MASK: u8 = 0x0F;
 
@@ -201,14 +201,14 @@ impl From<u8> for CartType {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum RomCoProcessor {
-    DSP = 0x00,
+    DSP     = 0x00,
     SuperFX = 0x01,
-    OBC1 = 0x02,
-    SA1 = 0x03,
-    SDD1 = 0x04,
-    SRTC = 0x05,
-    Other = 0x0E, // Super Game Boy or Satellaview, out of scope
-    Custom = 0x0F,
+    OBC1    = 0x02,
+    SA1     = 0x03,
+    SDD1    = 0x04,
+    SRTC    = 0x05,
+    Other   = 0x0E, // Super Game Boy or Satellaview, out of scope
+    Custom  = 0x0F,
     None,
 }
 const ROM_COPROCESSOR_MASK: u8 = 0xF0;
@@ -234,11 +234,11 @@ impl From<u8> for RomCoProcessor {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum CustomCoProcessor {
-    SPC7110 = 0x00,
+    SPC7110  = 0x00,
     ST010_11 = 0x01,
-    ST018 = 0x02,
-    CX4 = 0x03,
-    None = 0x04,
+    ST018    = 0x02,
+    CX4      = 0x03,
+    None     = 0x04,
 }
 
 impl From<u8> for CustomCoProcessor {
@@ -257,25 +257,25 @@ impl From<u8> for CustomCoProcessor {
 #[derive(Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum RomRegion {
-    Japan = 0x00,
-    USA = 0x01,
-    Europe = 0x02,
-    Sweden = 0x03,
-    Japan2 = 0x04,
-    Denmark = 0x05,
-    France = 0x06,
-    Netherlands = 0x07,
-    Spain = 0x08,
-    Germany = 0x09,
-    Italy = 0x0A,
-    China = 0x0B,
-    Indonesia = 0x0C,
-    SouthKorea = 0x0D,
+    Japan         = 0x00,
+    USA           = 0x01,
+    Europe        = 0x02,
+    Sweden        = 0x03,
+    Japan2        = 0x04,
+    Denmark       = 0x05,
+    France        = 0x06,
+    Netherlands   = 0x07,
+    Spain         = 0x08,
+    Germany       = 0x09,
+    Italy         = 0x0A,
+    China         = 0x0B,
+    Indonesia     = 0x0C,
+    SouthKorea    = 0x0D,
     International = 0x0E,
-    Canada = 0x0F,
-    Brazil = 0x10,
-    Australia = 0x11,
-    None = 0x12, // Used internally only
+    Canada        = 0x0F,
+    Brazil        = 0x10,
+    Australia     = 0x11,
+    None          = 0x12, // Used internally only
 }
 
 impl From<u8> for RomRegion {
@@ -405,7 +405,8 @@ pub fn load_rom(
                 rom[offset],
             );
         }
-    } else {
+    }
+    else {
         // Grab the header from the ROM to determine what size it is.
         data = fetch_header(&rom)?;
         fetch_opt_header(&rom, &mut data);
@@ -444,7 +445,8 @@ fn read_rom_to_buf(path: PathBuf) -> Result<Vec<u8>, RomReadError> {
             Ok(_) => {
                 if buf.capacity() != 0 {
                     retval = Ok(buf);
-                } else {
+                }
+                else {
                     retval = Err(RomReadError::from("Rom was of length 0"));
                 }
             }
@@ -452,7 +454,8 @@ fn read_rom_to_buf(path: PathBuf) -> Result<Vec<u8>, RomReadError> {
                 retval = Err(RomReadError::from(format!("Failed to read file: {}", e)));
             }
         };
-    } else {
+    }
+    else {
         retval = Err(RomReadError::from(format!(
             "Failed to open file at {}",
             &path.display()
@@ -630,7 +633,8 @@ fn fetch_header(rom: &Vec<u8>) -> Result<RomData, RomReadError> {
         for index in 0..rom.capacity() - 1 {
             checksum += Wrapping(rom[index] as u16);
         }
-    } else {
+    }
+    else {
         // Otherwise, find the highest power of 2 available and then multiply the following data to equal that size.
         // e.g.:
         //      1.5 MiB rom will be 1 MiB + (0.5 * 2).
@@ -717,7 +721,8 @@ fn populate_rom_mapping(data: &mut RomData) -> Result<(), RomReadError> {
     // Find the ROM clock speed.
     if data.header[HDR_MAP_MODE_INDEX] & MAP_FASTROM_MASK != 0 {
         data.mode.speed = RomClkSpeed::FastRom;
-    } else {
+    }
+    else {
         data.mode.speed = RomClkSpeed::SlowRom;
     }
 
@@ -812,11 +817,14 @@ fn test_checksum(checksum: u16, header: &Header) -> Result<RomSize, RomReadError
         let rom_map_mode: u8 = header[HDR_MAP_MODE_INDEX];
         if (rom_map_mode & MAP_EXHIROM_MASK) != 0 {
             retval = Ok(RomSize::ExHiRom);
-        } else if (rom_map_mode & MAP_HIROM_MASK) != 0 {
+        }
+        else if (rom_map_mode & MAP_HIROM_MASK) != 0 {
             retval = Ok(RomSize::HiRom);
-        } else if (rom_map_mode & MAP_BASE_MASK) != 0 {
+        }
+        else if (rom_map_mode & MAP_BASE_MASK) != 0 {
             retval = Ok(RomSize::LoRom);
-        } else {
+        }
+        else {
             retval = Err(RomReadError::from(
                 "ROM Checksum was valid, but mapping mode was unreadable",
             ));
@@ -1003,14 +1011,10 @@ mod tests {
         }
 
         #[test]
-        fn test_fetch_optional_lorom() {
-            test_fetch_optional_header(RomSize::LoRom);
-        }
+        fn test_fetch_optional_lorom() { test_fetch_optional_header(RomSize::LoRom); }
 
         #[test]
-        fn test_fetch_exception_headers_lorom() {
-            test_fetch_exception_headers(RomSize::LoRom);
-        }
+        fn test_fetch_exception_headers_lorom() { test_fetch_exception_headers(RomSize::LoRom); }
     }
 
     mod hirom_tests {
@@ -1025,14 +1029,10 @@ mod tests {
         }
 
         #[test]
-        fn test_fetch_optional_hirom() {
-            test_fetch_optional_header(RomSize::HiRom);
-        }
+        fn test_fetch_optional_hirom() { test_fetch_optional_header(RomSize::HiRom); }
 
         #[test]
-        fn test_fetch_exception_headers_hirom() {
-            test_fetch_exception_headers(RomSize::HiRom);
-        }
+        fn test_fetch_exception_headers_hirom() { test_fetch_exception_headers(RomSize::HiRom); }
     }
 
     mod exhirom_tests {
@@ -1047,9 +1047,7 @@ mod tests {
         }
 
         #[test]
-        fn test_fetch_optional_exhirom() {
-            test_fetch_optional_header(RomSize::ExHiRom);
-        }
+        fn test_fetch_optional_exhirom() { test_fetch_optional_header(RomSize::ExHiRom); }
 
         #[test]
         fn test_fetch_exception_headers_exhirom() {


### PR DESCRIPTION
# Description
Makes various small-and-medium size changes to the functionality of the debugger for ease-of-use.

- The debug print is shown on every CPU cycle instead of only on demand by running `print`
- The debug print now shows the value which is at the PC as well as the instruction that corresponds to.
- The table in `parser_data` has been simplified.
- The messages shown when setting or updating breakpoints has been made clearer.

# Tests Added / Tests Performed

# Review Checks:
- [x] All new functions and structs have rustdoc headers which cover all parameters and return values.
- [x] Where possible, tests have been written for new functionality. 
- [x] All unnecessary and dangling print statements have been removed. 
- [x] Compiler warnings have been cleared, or otherwise noted in the description of the Pull Request.
- [x] Any added functionality or updates to `README.md` have been performed.
    