### PR TITLE
Fix misleading print statement

### DIFF
--- a/src/cpu/registers.rs
+++ b/src/cpu/registers.rs
@@ -51,7 +51,7 @@ impl CpuRegisters {
     /// Print the current state of the CPU.
     pub fn print_state(&self) {
         println!(
-            "\nPC: {:#08X} ACC: {:#06X} SP: {:#06X}\nData Bank: {:#04X} Prog Bank: {:#04X} Direct Page: {:#06X}"
+            "\nPC: {:#06X} ACC: {:#06X} SP: {:#06X}\nData Bank: {:#04X} Prog Bank: {:#04X} Direct Page: {:#06X}"
              ,self.pc, self.acc, self.stack_ptr, self.data_bank, self.program_bank, self.direct_page,
         );
     }


### PR DESCRIPTION
# Description

# Tests Added / Tests Performed

# Review Checks:
- [ ] All new functions and structs have rustdoc headers which cover all parameters and return values.
- [ ] Where possible, tests have been written for new functionality. 
- [ ] All unnecessary and dangling print statements have been removed. 
- [ ] Compiler warnings have been cleared, or otherwise noted in the description of the Pull Request.
- [ ] Any added functionality or updates to `README.md` have been performed.
    